### PR TITLE
Fixing newMaxBitrate calculations

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -493,16 +493,13 @@ class Room extends EventEmitter
 		const previousMaxBitrate = this._maxBitrate;
 		let newMaxBitrate;
 
-		if (numPeers <= 2)
+		if (numPeers < 2)
 		{
 			newMaxBitrate = MAX_BITRATE;
 		}
 		else
 		{
-			newMaxBitrate = Math.round(MAX_BITRATE / ((numPeers - 1) * BITRATE_FACTOR));
-
-			if (newMaxBitrate < MIN_BITRATE)
-				newMaxBitrate = MIN_BITRATE;
+			newMaxBitrate = Math.max(Math.floor(MAX_BITRATE / numPeers * BITRATE_FACTOR), MIN_BITRATE);
 		}
 
 		this._maxBitrate = newMaxBitrate;


### PR DESCRIPTION
If `numPeers <= 2` then each peer had its bitrate set to the MAX_BITRATE, meaning if there were two peers the MAX_BITRATE was violated (doubled)

`Math.round(MAX_BITRATE / ((numPeers - 1) * BITRATE_FACTOR));`
The -1 is incorrect here, as it causes the calculated bitrate to always be too high

Also, a question: What is the bitrate factor for? I'm not quite familiar with this