### PR TITLE
Fix the "no Peer found ..." error

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -747,7 +747,6 @@ class Room extends EventEmitter
 				// Tell the new Peer about already joined Peers.
 				// And also create Consumers for existing Producers.
 
-				const peerInfos = [];
 				const joinedPeers =
 				[
 					...this._getJoinedPeers(),
@@ -755,6 +754,13 @@ class Room extends EventEmitter
 				];
 
 				// Reply now the request with the list of joined peers (all but the new one).
+				const peerInfos = joinedPeers
+					.filter((joinedPeer) => joinedPeer.id !== peer.id)
+					.map((joinedPeer) => ({
+						id          : joinedPeer.id,
+						displayName : joinedPeer.data.displayName,
+						device      : joinedPeer.data.device
+					}));
 				accept({ peers: peerInfos });
 
 				// Mark the new Peer as joined.
@@ -762,13 +768,6 @@ class Room extends EventEmitter
 
 				for (const joinedPeer of joinedPeers)
 				{
-					peerInfos.push(
-						{
-							id          : joinedPeer.id,
-							displayName : joinedPeer.data.displayName,
-							device      : joinedPeer.data.device
-						});
-
 					// Create Consumers for existing Producers.
 					for (const producer of joinedPeer.data.producers.values())
 					{

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -751,7 +751,7 @@ class Room extends EventEmitter
 				const joinedPeers =
 				[
 					...this._getJoinedPeers(),
-					...Array.from(this._broadcasters.values())
+					...this._broadcasters.values()
 				];
 
 				// Reply now the request with the list of joined peers (all but the new one).


### PR DESCRIPTION
This error occurs when you join a room:
![image](https://user-images.githubusercontent.com/13188494/68624354-aa56e780-04e7-11ea-8324-325adbc72852.png)

It's happening because a list of current peers is sent empty from the server to a client:
https://github.com/versatica/mediasoup-demo/blob/29205245bd0441304f1249ddeb60fefeea6379d3/server/lib/Room.js#L758
And this list is filled after `accept`:
https://github.com/versatica/mediasoup-demo/blob/29205245bd0441304f1249ddeb60fefeea6379d3/server/lib/Room.js#L765-L770

Judging by the history, the error began to occur after the commit: a78aaca5d6597b79470093d62879c5f8a81fa09b.

There are two options to fix this:
* Revert the a78aaca5d6597b79470093d62879c5f8a81fa09b commit: send the peer list after requests to create consumers;
* Send the list before the requests to create consumers, but then we get an extra loop to fill an array

I've implemented the second option: filled the `peerInfos` before the `accept` calling.

Tested on:
* _Commit_: 29205245bd0441304f1249ddeb60fefeea6379d3;
* _OS_: Windows + Docker
* _Browser_: Chrome 78.0.3904.97 