### PR TITLE
Allow joining a room without having a microphone

### DIFF
--- a/app/lib/RoomClient.js
+++ b/app/lib/RoomClient.js
@@ -2068,22 +2068,22 @@ export default class RoomClient
 
 			await this._mediasoupDevice.load({ routerRtpCapabilities });
 
-			// NOTE: Stuff to play remote audios due to browsers' new autoplay policy.
-			//
-			// Just get access to the mic and DO NOT close the mic track for a while.
-			// Super hack!
-			{
-				const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-				const audioTrack = stream.getAudioTracks()[0];
-
-				audioTrack.enabled = false;
-
-				setTimeout(() => audioTrack.stop(), 120000);
-			}
-
 			// Create mediasoup Transport for sending (unless we don't want to produce).
 			if (this._produce)
 			{
+				// NOTE: Stuff to play remote audios due to browsers' new autoplay policy.
+				//
+				// Just get access to the mic and DO NOT close the mic track for a while.
+				// Super hack!
+				{
+					const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+					const audioTrack = stream.getAudioTracks()[0];
+
+					audioTrack.enabled = false;
+
+					setTimeout(() => audioTrack.stop(), 120000);
+				}
+				
 				const transportInfo = await this._protoo.request(
 					'createWebRtcTransport',
 					{


### PR DESCRIPTION
Just a small refactoring to allow joining a room even if the client's (app) computer does not have a microphone (by using the **produce=false** query parameter).