### PR TITLE
Pausing/Resuming local consumers on notification.

### DIFF
--- a/app/lib/RoomClient.js
+++ b/app/lib/RoomClient.js
@@ -672,6 +672,8 @@ export default class RoomClient
 
 					if (!consumer)
 						break;
+					
+					consumer.pause();
 
 					store.dispatch(
 						stateActions.setConsumerPaused(consumerId, 'remote'));
@@ -686,6 +688,8 @@ export default class RoomClient
 
 					if (!consumer)
 						break;
+					
+					consumer.resume();
 
 					store.dispatch(
 						stateActions.setConsumerResumed(consumerId, 'remote'));


### PR DESCRIPTION
If we don't pause local consumer object when the remote consumer is paused a slight 'hiss' can be heard. Its not a problem in a room with 2-3 people but with more people if everyone speaks and then mutes themselves a loud hissing noise can be heard.

Calling pause stops the track so the hiss goes away completely and it feels much better.