### PR TITLE
Add libmediasoup data channel demo

### DIFF
--- a/app/lib/RoomClient.js
+++ b/app/lib/RoomClient.js
@@ -2147,7 +2147,6 @@ export default class RoomClient
 
 				setTimeout(() => audioTrack.stop(), 120000);
 			}
-			
 			// Create mediasoup Transport for sending (unless we don't want to produce).
 			if (this._produce)
 			{

--- a/app/lib/RoomClient.js
+++ b/app/lib/RoomClient.js
@@ -2135,22 +2135,22 @@ export default class RoomClient
 
 			await this._mediasoupDevice.load({ routerRtpCapabilities });
 
+			// NOTE: Stuff to play remote audios due to browsers' new autoplay policy.
+			//
+			// Just get access to the mic and DO NOT close the mic track for a while.
+			// Super hack!
+			{
+				const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+				const audioTrack = stream.getAudioTracks()[0];
+
+				audioTrack.enabled = false;
+
+				setTimeout(() => audioTrack.stop(), 120000);
+			}
+			
 			// Create mediasoup Transport for sending (unless we don't want to produce).
 			if (this._produce)
 			{
-				// NOTE: Stuff to play remote audios due to browsers' new autoplay policy.
-				//
-				// Just get access to the mic and DO NOT close the mic track for a while.
-				// Super hack!
-				{
-					const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-					const audioTrack = stream.getAudioTracks()[0];
-
-					audioTrack.enabled = false;
-
-					setTimeout(() => audioTrack.stop(), 120000);
-				}
-				
 				const transportInfo = await this._protoo.request(
 					'createWebRtcTransport',
 					{

--- a/app/lib/RoomClient.js
+++ b/app/lib/RoomClient.js
@@ -2068,22 +2068,22 @@ export default class RoomClient
 
 			await this._mediasoupDevice.load({ routerRtpCapabilities });
 
-			// NOTE: Stuff to play remote audios due to browsers' new autoplay policy.
-			//
-			// Just get access to the mic and DO NOT close the mic track for a while.
-			// Super hack!
-			{
-				const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-				const audioTrack = stream.getAudioTracks()[0];
-
-				audioTrack.enabled = false;
-
-				setTimeout(() => audioTrack.stop(), 120000);
-			}
-
 			// Create mediasoup Transport for sending (unless we don't want to produce).
 			if (this._produce)
 			{
+				// NOTE: Stuff to play remote audios due to browsers' new autoplay policy.
+				//
+				// Just get access to the mic and DO NOT close the mic track for a while.
+				// Super hack!
+				{
+					const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+					const audioTrack = stream.getAudioTracks()[0];
+
+					audioTrack.enabled = false;
+
+					setTimeout(() => audioTrack.stop(), 120000);
+				}
+				
 				const transportInfo = await this._protoo.request(
 					'createWebRtcTransport',
 					{

--- a/server/server.js
+++ b/server/server.js
@@ -443,7 +443,7 @@ async function runHttpsServer()
 
 /**
  * Create a protoo WebSocketServer to allow WebSocket connections from browsers.
- */ 
+ */
 async function runProtooWebSocketServer()
 {
 	logger.info('running protoo WebSocketServer...');

--- a/server/server.js
+++ b/server/server.js
@@ -224,7 +224,7 @@ async function createExpressApp()
 		async (req, res, next) =>
 		{
 			const { broadcasterId } = req.params;
-			const { type, rtcpMux, comedia } = req.body;
+			const { type, rtcpMux, comedia, sctpCapabilities } = req.body;
 
 			try
 			{
@@ -233,7 +233,8 @@ async function createExpressApp()
 						broadcasterId,
 						type,
 						rtcpMux,
-						comedia
+						comedia, 
+						sctpCapabilities
 					});
 
 				res.status(200).json(data);
@@ -334,6 +335,67 @@ async function createExpressApp()
 		});
 
 	/**
+	 * POST API to create a mediasoup DataConsumer associated to a Broadcaster.
+	 * The exact Transport in which the DataConsumer must be created is signaled in
+	 * the URL path. Query body must include the desired producerId to
+	 * consume.
+	 */
+	expressApp.post(
+		'/rooms/:roomId/broadcasters/:broadcasterId/transports/:transportId/consume/data',
+		async (req, res, next) =>
+		{
+			const { broadcasterId, transportId } = req.params;
+			const { dataProducerId } = req.body;
+
+			try
+			{
+				const data = await req.room.createBroadcasterDataConsumer(
+					{
+						broadcasterId,
+						transportId,
+						dataProducerId
+					});
+
+				res.status(200).json(data);
+			}
+			catch (error)
+			{
+				next(error);
+			}
+		});
+	
+	/**
+	 * POST API to create a mediasoup DataProducer associated to a Broadcaster.
+	 * The exact Transport in which the DataProducer must be created is signaled in
+	 */
+	expressApp.post(
+		'/rooms/:roomId/broadcasters/:broadcasterId/transports/:transportId/produce/data',
+		async (req, res, next) =>
+		{
+			const { broadcasterId, transportId } = req.params;
+			const { label, protocol, sctpStreamParameters, appData } = req.body;
+
+			try
+			{
+				const data = await req.room.createBroadcasterDataProducer(
+					{
+						broadcasterId,
+						transportId,
+						label,
+						protocol,
+						sctpStreamParameters,
+						appData
+					});
+
+				res.status(200).json(data);
+			}
+			catch (error)
+			{
+				next(error);
+			}
+		});
+
+	/**
 	 * Error handler.
 	 */
 	expressApp.use(
@@ -381,7 +443,7 @@ async function runHttpsServer()
 
 /**
  * Create a protoo WebSocketServer to allow WebSocket connections from browsers.
- */
+ */ 
 async function runProtooWebSocketServer()
 {
 	logger.info('running protoo WebSocketServer...');


### PR DESCRIPTION
This PR is to be used in conjunction with the [mediasoup-broadcaster-demo PR,](https://github.com/versatica/mediasoup-broadcaster-demo/pull/10) demonstrating datachannel usage from libmediasoupclient. See also the [libmediasoupclient PR](https://github.com/versatica/libmediasoupclient/pull/77).

The example is a simple dataproducer->dataconsumer loopback from mediasoup-broadcaster-demo through mediasoup-demo:

mediasoup-broadcaster-demo --(msg)-->mediasoup-demo --(msg)--> mediasoup-broadcaster-demo