### PR TITLE
scalabilityMode L3T3 in latest version of Chrome/Edge does not work.

### DIFF
--- a/app/lib/RoomClient.js
+++ b/app/lib/RoomClient.js
@@ -1423,7 +1423,7 @@ export default class RoomClient
 					[
 						{
 							maxBitrate      : 5000000,
-							scalabilityMode : 'L3T3',
+							scalabilityMode : this._sharingScalabilityMode || 'L3T1',
 							dtx             : true
 						}
 					];


### PR DESCRIPTION
scalabilityMode L3T3 in latest version of Chrome/Edge does not work when sharing screen, change to L3T1.