### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `forceVP9`        | Boolean | Force VP9 codec for webcam and screen sharing | `false` |
 | `enableWebcamLayers` | Boolean | Enable simulcast or SVC for webcam | `true` |
 | `enableSharingLayers` | Boolean | Enable simulcast or SVC for screen sharing | `true` |
-| `webcamScalabilityMode` | String | `scalabilityMode` for webcam | 'L1T3' for VP8/H264 (in each simculast encoding), 'L3T3_KEY' for VP9 |
-| `sharingScalabilityMode` | String | `scalabilityMode` for screen sharing | 'L1T3' for VP8/H264 (in each simculast encoding), 'L3T3' for VP9 |
+| `webcamScalabilityMode` | String | `scalabilityMode` for webcam | 'L1T3' for VP8/H264 (in each simulcast encoding), 'L3T3_KEY' for VP9 |
+| `sharingScalabilityMode` | String | `scalabilityMode` for screen sharing | 'L1T3' for VP8/H264 (in each simulcast encoding), 'L3T3' for VP9 |
 | `numSimulcastStreams` | Number | Number of streams for simulcast in webcam and screen sharing | 3 |
 | `info`             | Boolean | Display detailed information about media transmission | `false` |
 | `faceDetection`    | Boolean | Run face detection | `false` |


### PR DESCRIPTION
change `simculast` to simulcast.
Ref: https://mediasoup.discourse.group/t/fix-typo-simculast-simulcast/5021