### PR TITLE
Add local mediasoup-client development mode

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,10 @@
     "start:tcp": "cross-env DEV=tcp vite",
     "start:vp9": "cross-env DEV=vp9 vite",
     "start:h264": "cross-env DEV=h264 vite",
+    "local": "cross-env LOCAL=1 DEV=. vite",
+    "local:tcp": "cross-env LOCAL=1 DEV=tcp vite",
+    "local:vp9": "cross-env LOCAL=1 DEV=vp9 vite",
+    "local:h264": "cross-env LOCAL=1 DEV=h264 vite",
     "build": "vite build",
     "lint": "eslint --fix --ext=.js,.jsx src && prettier --write --log-level=error src"
   },

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -22,6 +22,12 @@ try {
 const port = Number(process.env.VITE_LISTEN_PORT) || 3000;
 const https = cert && key ? { cert, key } : undefined;
 
+const alias: {[k: string]: string} = {}
+if (process.env.LOCAL) {
+  const localClientEntryPoint = '../../mediasoup-client/src/index.ts'
+  alias['mediasoup-client'] = path.join(__dirname, localClientEntryPoint)
+}
+
 export default defineConfig({
   plugins: [react()],
   build: {
@@ -31,6 +37,9 @@ export default defineConfig({
     host,
     port,
     https,
+  },
+  resolve: {
+    alias,
   },
 });
 


### PR DESCRIPTION
Fixed #130

Check vite.config.ts where you can define the path to your local mediasoup-client location. By default, it assume the client is in the same folder with this demo.
To start development with local client `npm run local`, please check package.json where there are other commands similar to `npm start`