### PR TITLE
Test gstreamer consumer

### DIFF
--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1231,7 +1231,6 @@ class Room extends EventEmitter
 				// 				protocol  : 'udp',
 				// 				ip        : '127.0.0.1',
 				// 				// NOTE: Adapt ports to your config.
-				// 				// // NOTE: Adapt ports to your config.
 				// 				portRange : { min: 2010, max: 2020 }
 				// 			}
 				// 		}

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1216,15 +1216,40 @@ class Room extends EventEmitter
 				// 	directProducer.send(buffer);
 				// });
 
-				// Add into the AudioLevelObserver and ActiveSpeakerObserver.
-				if (producer.kind === 'audio')
-				{
-					this._audioLevelObserver.addProducer({ producerId: producer.id })
-						.catch(() => {});
+				/* Test gstreamer.
+				 *
+				 * NOTE: Adapt payloadType to the consumer's payloadType.
+				 * gst-launch-1.0 -v udpsrc port=5004\
+				 * caps="application/x-rtp, media=(string)video, encoding-name=(string)H264, payload=(int)107"\
+				 * ! rtpjitterbuffer ! rtph264depay ! avdec_h264 ! autovideosink
+				 */
+				// if (kind === 'video')
+				// {
+				// 	const plainTransport = await this._mediasoupRouter.createPlainTransport(
+				// 		{
+				// 			listenInfo : {
+				// 				protocol  : 'udp',
+				// 				ip        : '127.0.0.1',
+				// 				// NOTE: Adapt ports to your config.
+				// 				// // NOTE: Adapt ports to your config.
+				// 				portRange : { min: 2010, max: 2020 }
+				// 			}
+				// 		}
+				// 	);
 
-					this._activeSpeakerObserver.addProducer({ producerId: producer.id })
-						.catch(() => {});
-				}
+				// 	plainTransport.connect({ ip: '127.0.0.1', port: 5004 });
+
+				// 	const consumer = await plainTransport.consume(
+				// 		{
+				// 			producerId      : producer.id,
+				// 			rtpCapabilities : this._mediasoupRouter.rtpCapabilities
+				// 		}
+				// 	);
+
+				// 	const dump = await consumer.dump();
+
+				// 	logger.info(`payloadType: ${dump.rtpStream.params.payloadType}`);
+				// }
 
 				break;
 			}

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1251,6 +1251,16 @@ class Room extends EventEmitter
 				// 	logger.info(`payloadType: ${dump.rtpStream.params.payloadType}`);
 				// }
 
+				// Add into the AudioLevelObserver and ActiveSpeakerObserver.
+				if (producer.kind === 'audio')
+				{
+					this._audioLevelObserver.addProducer({ producerId: producer.id })
+						.catch(() => {});
+
+					this._activeSpeakerObserver.addProducer({ producerId: producer.id })
+						.catch(() => {});
+				}
+
 				break;
 			}
 


### PR DESCRIPTION
For dev purposes, create a consumer on a plain transport where a gstreamer or another binary may be listening.