### PR TITLE
Server: option to create PipeTransports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `externalVideo`    | Boolean | Send an external video instead of local webcam | `false` |
 | `e2eKey`           | String | Key for media E2E encryption/decryption (just works with some OPUS and VP8 codecs) | |
 | `consumerReplicas` | Number | Create artificial replicas of yourself and receive their audio and video (not displayed in the UI) | 0 |
+| `usePipeTransports` | Boolean | If `true`, each room will use separate mediasoup routers to produce and consume and will communicate them with pipe transports | `false` |
 
 
 ## Installation

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -58,6 +58,7 @@ export default class RoomClient {
 		externalVideo,
 		e2eKey,
 		consumerReplicas,
+		usePipeTransports,
 		stats,
 	}) {
 		logger.debug(
@@ -188,7 +189,12 @@ export default class RoomClient {
 
 		// Protoo URL.
 		// @type {String}
-		this._protooUrl = getProtooUrl({ roomId, peerId, consumerReplicas });
+		this._protooUrl = getProtooUrl({
+			roomId,
+			peerId,
+			consumerReplicas,
+			usePipeTransports,
+		});
 
 		// protoo-client Peer instance.
 		// @type {protooClient.Peer}

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -96,6 +96,7 @@ async function run() {
 	const throttleSecret = urlParser.query.throttleSecret;
 	const e2eKey = urlParser.query.e2eKey;
 	const consumerReplicas = urlParser.query.consumerReplicas;
+	const usePipeTransports = urlParser.query.usePipeTransports === 'true';
 
 	// Enable face detection on demand.
 	if (faceDetection)
@@ -150,7 +151,8 @@ async function run() {
 			case 'externalVideo':
 			case 'throttleSecret':
 			case 'e2eKey':
-			case 'consumerReplicas': {
+			case 'consumerReplicas':
+			case 'usePipeTransports': {
 				break;
 			}
 
@@ -212,6 +214,7 @@ async function run() {
 		externalVideo,
 		e2eKey,
 		consumerReplicas,
+		usePipeTransports,
 		stats,
 	});
 

--- a/app/src/urlFactory.js
+++ b/app/src/urlFactory.js
@@ -9,9 +9,6 @@ if (window.location.hostname === 'test.mediasoup.org') {
 const hostname = window.location.hostname;
 const protocol = 'wss';
 
-// const hostname = 'v3demo.mediasoup.org'
-// const protocol = 'ws'
-
 export function getProtooUrl(params) {
 	const query = qs.stringify(params);
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,7 @@
 				"body-parser": "^2.2.0",
 				"debug": "^4.4.3",
 				"express": "^5.1.0",
-				"mediasoup": "^3.19.3",
+				"mediasoup": "^3.19.4",
 				"picocolors": "^1.1.1",
 				"pidusage": "^4.0.1",
 				"protoo-server": "^4.0.7",
@@ -28,7 +28,7 @@
 				"@eslint/js": "^9.37.0",
 				"@types/debug": "^4.1.12",
 				"@types/express": "^5.0.3",
-				"@types/node": "^24.7.0",
+				"@types/node": "^24.8.1",
 				"@types/pidusage": "^2.0.5",
 				"@types/protoo-server": "^4.0.6",
 				"eslint": "^9.37.0",
@@ -39,7 +39,7 @@
 				"prettier": "^3.6.2",
 				"tsx": "^4.20.6",
 				"typescript": "^5.9.3",
-				"typescript-eslint": "^8.46.0"
+				"typescript-eslint": "^8.46.1"
 			},
 			"engines": {
 				"node": ">=22"
@@ -876,9 +876,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.7.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.0.tgz",
-			"integrity": "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==",
+			"version": "24.8.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+			"integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -951,17 +951,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.0.tgz",
-			"integrity": "sha512-hA8gxBq4ukonVXPy0OKhiaUh/68D0E88GSmtC1iAEnGaieuDi38LhS7jdCHRLi6ErJBNDGCzvh5EnzdPwUc0DA==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
+			"integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.46.0",
-				"@typescript-eslint/type-utils": "8.46.0",
-				"@typescript-eslint/utils": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0",
+				"@typescript-eslint/scope-manager": "8.46.1",
+				"@typescript-eslint/type-utils": "8.46.1",
+				"@typescript-eslint/utils": "8.46.1",
+				"@typescript-eslint/visitor-keys": "8.46.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -975,7 +975,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.46.0",
+				"@typescript-eslint/parser": "^8.46.1",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
@@ -991,16 +991,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.0.tgz",
-			"integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
+			"integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.0",
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0",
+				"@typescript-eslint/scope-manager": "8.46.1",
+				"@typescript-eslint/types": "8.46.1",
+				"@typescript-eslint/typescript-estree": "8.46.1",
+				"@typescript-eslint/visitor-keys": "8.46.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1016,14 +1016,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.0.tgz",
-			"integrity": "sha512-OEhec0mH+U5Je2NZOeK1AbVCdm0ChyapAyTeXVIYTPXDJ3F07+cu87PPXcGoYqZ7M9YJVvFnfpGg1UmCIqM+QQ==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
+			"integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.46.0",
-				"@typescript-eslint/types": "^8.46.0",
+				"@typescript-eslint/tsconfig-utils": "^8.46.1",
+				"@typescript-eslint/types": "^8.46.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1038,14 +1038,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.0.tgz",
-			"integrity": "sha512-lWETPa9XGcBes4jqAMYD9fW0j4n6hrPtTJwWDmtqgFO/4HF4jmdH/Q6wggTw5qIT5TXjKzbt7GsZUBnWoO3dqw==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
+			"integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0"
+				"@typescript-eslint/types": "8.46.1",
+				"@typescript-eslint/visitor-keys": "8.46.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1056,9 +1056,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.0.tgz",
-			"integrity": "sha512-WrYXKGAHY836/N7zoK/kzi6p8tXFhasHh8ocFL9VZSAkvH956gfeRfcnhs3xzRy8qQ/dq3q44v1jvQieMFg2cw==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
+			"integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1073,15 +1073,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.0.tgz",
-			"integrity": "sha512-hy+lvYV1lZpVs2jRaEYvgCblZxUoJiPyCemwbQZ+NGulWkQRy0HRPYAoef/CNSzaLt+MLvMptZsHXHlkEilaeg==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
+			"integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0",
-				"@typescript-eslint/utils": "8.46.0",
+				"@typescript-eslint/types": "8.46.1",
+				"@typescript-eslint/typescript-estree": "8.46.1",
+				"@typescript-eslint/utils": "8.46.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -1098,9 +1098,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.0.tgz",
-			"integrity": "sha512-bHGGJyVjSE4dJJIO5yyEWt/cHyNwga/zXGJbJJ8TiO01aVREK6gCTu3L+5wrkb1FbDkQ+TKjMNe9R/QQQP9+rA==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
+			"integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1112,16 +1112,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.0.tgz",
-			"integrity": "sha512-ekDCUfVpAKWJbRfm8T1YRrCot1KFxZn21oV76v5Fj4tr7ELyk84OS+ouvYdcDAwZL89WpEkEj2DKQ+qg//+ucg==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
+			"integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.46.0",
-				"@typescript-eslint/tsconfig-utils": "8.46.0",
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/visitor-keys": "8.46.0",
+				"@typescript-eslint/project-service": "8.46.1",
+				"@typescript-eslint/tsconfig-utils": "8.46.1",
+				"@typescript-eslint/types": "8.46.1",
+				"@typescript-eslint/visitor-keys": "8.46.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -1167,16 +1167,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.0.tgz",
-			"integrity": "sha512-nD6yGWPj1xiOm4Gk0k6hLSZz2XkNXhuYmyIrOWcHoPuAhjT9i5bAG+xbWPgFeNR8HPHHtpNKdYUXJl/D3x7f5g==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
+			"integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.46.0",
-				"@typescript-eslint/types": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0"
+				"@typescript-eslint/scope-manager": "8.46.1",
+				"@typescript-eslint/types": "8.46.1",
+				"@typescript-eslint/typescript-estree": "8.46.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1191,13 +1191,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.0.tgz",
-			"integrity": "sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
+			"integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.46.0",
+				"@typescript-eslint/types": "8.46.1",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -2746,23 +2746,23 @@
 			}
 		},
 		"node_modules/mediasoup": {
-			"version": "3.19.3",
-			"resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.19.3.tgz",
-			"integrity": "sha512-1BH68i/q/hVAuSQHFCMq6TJDwca74KMtxE7k79BGD+wrnkvi3PTpaNaVjJ/JLjpCZnBZ3WrtI3Js0nw7NHSAXw==",
+			"version": "3.19.4",
+			"resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.19.4.tgz",
+			"integrity": "sha512-ADDeBlo6lfM7Id4EuGx0huH7G8ii1tx8D9a3uQwrZINMHsNugRsjOsHHms6VyHfDfkMz8C4F5v2nOVWeEQYqSA==",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {
 				"@types/ini": "^4.1.1",
 				"debug": "^4.4.3",
-				"flatbuffers": "^25.2.10",
-				"h264-profile-level-id": "^2.2.3",
+				"flatbuffers": "^25.9.23",
+				"h264-profile-level-id": "^2.3.1",
 				"ini": "^5.0.0",
 				"node-fetch": "^3.3.2",
 				"supports-color": "^10.2.2",
-				"tar": "^7.4.4"
+				"tar": "^7.5.1"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3791,16 +3791,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.46.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.0.tgz",
-			"integrity": "sha512-6+ZrB6y2bT2DX3K+Qd9vn7OFOJR+xSLDj+Aw/N3zBwUt27uTw2sw2TE2+UcY1RiyBZkaGbTkVg9SSdPNUG6aUw==",
+			"version": "8.46.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
+			"integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.46.0",
-				"@typescript-eslint/parser": "8.46.0",
-				"@typescript-eslint/typescript-estree": "8.46.0",
-				"@typescript-eslint/utils": "8.46.0"
+				"@typescript-eslint/eslint-plugin": "8.46.1",
+				"@typescript-eslint/parser": "8.46.1",
+				"@typescript-eslint/typescript-estree": "8.46.1",
+				"@typescript-eslint/utils": "8.46.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/server/package.json
+++ b/server/package.json
@@ -46,7 +46,7 @@
 		"body-parser": "^2.2.0",
 		"debug": "^4.4.3",
 		"express": "^5.1.0",
-		"mediasoup": "^3.19.3",
+		"mediasoup": "^3.19.4",
 		"picocolors": "^1.1.1",
 		"pidusage": "^4.0.1",
 		"protoo-server": "^4.0.7",
@@ -56,7 +56,7 @@
 		"@eslint/js": "^9.37.0",
 		"@types/debug": "^4.1.12",
 		"@types/express": "^5.0.3",
-		"@types/node": "^24.7.0",
+		"@types/node": "^24.8.1",
 		"@types/pidusage": "^2.0.5",
 		"@types/protoo-server": "^4.0.6",
 		"eslint": "^9.37.0",
@@ -67,6 +67,6 @@
 		"prettier": "^3.6.2",
 		"tsx": "^4.20.6",
 		"typescript": "^5.9.3",
-		"typescript-eslint": "^8.46.0"
+		"typescript-eslint": "^8.46.1"
 	}
 }

--- a/server/src/ApiServer.ts
+++ b/server/src/ApiServer.ts
@@ -44,6 +44,7 @@ export class ApiServer extends EnhancedEventEmitter<ApiServerEvents> {
 		logger.debug('create()');
 
 		const expressApp = ApiServer.createExpressApp();
+
 		const apiServer = new ApiServer({ expressApp, httpOriginHeader });
 
 		return apiServer;

--- a/server/src/BroadcasterPeer.ts
+++ b/server/src/BroadcasterPeer.ts
@@ -145,6 +145,7 @@ export class BroadcasterPeer extends EnhancedEventEmitter<BroadcasterPeerEvents>
 		staticLogger.debug('create() [peerId:%o]', peerId);
 
 		const logger = new Logger(`[peerId:${peerId}]`, staticLogger);
+
 		const broadcasterPeer = new BroadcasterPeer({
 			logger,
 			peerId,

--- a/server/src/Peer.ts
+++ b/server/src/Peer.ts
@@ -176,6 +176,7 @@ export class Peer extends EnhancedEventEmitter<PeerEvents> {
 		staticLogger.debug('create() [peerId:%o]', peerId);
 
 		const logger = new Logger(`[peerId:${peerId}]`, staticLogger);
+
 		const peer = new Peer({ logger, peerId, protooPeer, remoteAddress });
 
 		return peer;

--- a/server/src/WsServer.ts
+++ b/server/src/WsServer.ts
@@ -27,7 +27,7 @@ export type WsServerEvents = {
 	 * Emitted to create or get an existing Room.
 	 */
 	'get-or-create-room': [
-		{ roomId: RoomId; consumerReplicas: number },
+		{ roomId: RoomId; consumerReplicas: number; usePipeTransports: boolean },
 		resolve: (room: Room) => void,
 		reject: (error: Error) => void,
 	];
@@ -49,6 +49,7 @@ export class WsServer extends EnhancedEventEmitter<WsServerEvents> {
 			fragmentOutgoingMessages: true,
 			fragmentationThreshold: 960000,
 		});
+
 		const wsServer = new WsServer({ protooServer, httpOriginHeader });
 
 		return wsServer;
@@ -95,6 +96,7 @@ export class WsServer extends EnhancedEventEmitter<WsServerEvents> {
 			const roomId = params.get('roomId');
 			const peerId = params.get('peerId');
 			const consumerReplicas = Number(params.get('consumerReplicas') ?? 0);
+			const usePipeTransports = params.get('usePipeTransports') === 'true';
 
 			if (!roomId || !peerId) {
 				reject(400, 'Missing roomId and/or peerId');
@@ -115,7 +117,7 @@ export class WsServer extends EnhancedEventEmitter<WsServerEvents> {
 				const room = await new Promise<Room>((resolve, reject) => {
 					this.emit(
 						'get-or-create-room',
-						{ roomId, consumerReplicas },
+						{ roomId, consumerReplicas, usePipeTransports },
 						resolve,
 						reject
 					);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -65,7 +65,7 @@ export type PeerDevice = {
 
 export type SerializedServer = {
 	createdAt: Date;
-	numMediasoupWorkers: number;
+	numWorkers: number;
 	networkThrottleEnabled: boolean;
 	numRooms: number;
 	rooms: SerializedRoom[];


### PR DESCRIPTION
# Details

- New URL option `&usePipeTransports=true` to create a room that will handle 2 Routers that communicate with PipeTransports.
- Replaces PR #149 (credits to @vpalmisano).
- Also some renaming (remove "mediasoup" prefix from many class members and variables).