### PR TITLE
Integrate with rtcstats-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `e2eKey`           | String | Key for media E2E encryption/decryption (just works with some OPUS and VP8 codecs) | |
 | `consumerReplicas` | Number | Create artificial replicas of yourself and receive their audio and video (not displayed in the UI) | 0 |
 | `usePipeTransports` | Boolean | If `true`, each room will use separate mediasoup routers to produce and consume and will communicate them with pipe transports | `false` |
+| `rtcstatsUrl`      | String  | If present, Websocket URL to connect to an [rtcstats-server], including token | |
 
 
 ## Installation
@@ -83,3 +84,4 @@ npm install --legacy-peer-deps
 
 [github-actions-shield-mediasoup-demo-server]: https://github.com/versatica/mediasoup-demo/actions/workflows/mediasoup-demo-server.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-demo-server]: https://github.com/versatica/mediasoup-demo/actions/workflows/mediasoup-demo-server.yaml?query=branch%3Av3
+[rtcstats-server]: https://github.com/rtcstats/rtcstats

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "7.29.2",
+		"@rtcstats/rtcstats-js": "^2.2.2",
 		"awaitqueue": "^3.3.0",
 		"bowser": "2.14.1",
 		"classnames": "2.5.1",

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -21,6 +21,7 @@ import * as stateActions from './redux/stateActions';
 import reducers from './redux/reducers';
 import Room from './components/Room';
 import './scss/index.scss';
+import { wrapRTCStatsWithDefaultOptions } from '@rtcstats/rtcstats-js';
 
 const logger = new Logger();
 const reduxMiddlewares = [thunk];
@@ -46,6 +47,7 @@ domready(async () => {
 
 window.RUN = run;
 
+let rtcstatsTrace;
 async function run() {
 	logger.debug('run() [environment:%s]', process.env.NODE_ENV);
 
@@ -195,6 +197,11 @@ async function run() {
 	store.dispatch(
 		stateActions.setMe({ peerId, displayName, displayNameSet, device })
 	);
+	const rtcstatsUrl = urlParser.query.rtcstatsUrl;
+	if (rtcstatsUrl) {
+		rtcstatsTrace = wrapRTCStatsWithDefaultOptions();
+		rtcstatsTrace.connect(rtcstatsUrl);
+	}
 
 	roomClient = new RoomClient({
 		roomId,


### PR DESCRIPTION
with an `rtcstatsUrl` parameter which should contain the full rtcstats url including the token. This shows how to gather WebRTC API traces + getStats data similar to
  https://www.meetecho.com/blog/rtcstats-janus/

No further integration with mediasoup-client is required. Small JS "binary" size impact, ~6kb