### PR TITLE
Integrate rtcstats-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `e2eKey`           | String | Key for media E2E encryption/decryption (just works with some OPUS and VP8 codecs) | |
 | `consumerReplicas` | Number | Create artificial replicas of yourself and receive their audio and video (not displayed in the UI) | 0 |
 | `usePipeTransports` | Boolean | If `true`, each room will use separate mediasoup routers to produce and consume and will communicate them with pipe transports | `false` |
+| `rtcstatsUrl`      | String  | If present, Websocket URL to connect to an [rtcstats-server](https://github.com/rtcstats/rtcstats), including token (it overrides the `providers.rtcstatsUrl` value in `config.mjs` in the server)  | |
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `e2eKey`           | String | Key for media E2E encryption/decryption (just works with some OPUS and VP8 codecs) | |
 | `consumerReplicas` | Number | Create artificial replicas of yourself and receive their audio and video (not displayed in the UI) | 0 |
 | `usePipeTransports` | Boolean | If `true`, each room will use separate mediasoup routers to produce and consume and will communicate them with pipe transports | `false` |
-| `rtcstatsUrl`      | String  | If present, Websocket URL to connect to an [rtcstats-server](https://github.com/rtcstats/rtcstats), including token | |
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `e2eKey`           | String | Key for media E2E encryption/decryption (just works with some OPUS and VP8 codecs) | |
 | `consumerReplicas` | Number | Create artificial replicas of yourself and receive their audio and video (not displayed in the UI) | 0 |
 | `usePipeTransports` | Boolean | If `true`, each room will use separate mediasoup routers to produce and consume and will communicate them with pipe transports | `false` |
+| `rtcstatsUrl`      | String  | If present, Websocket URL to connect to an [rtcstats-server], including token | |
 
 
 ## Installation
@@ -83,3 +84,4 @@ npm install --legacy-peer-deps
 
 [github-actions-shield-mediasoup-demo-server]: https://github.com/versatica/mediasoup-demo/actions/workflows/mediasoup-demo-server.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-demo-server]: https://github.com/versatica/mediasoup-demo/actions/workflows/mediasoup-demo-server.yaml?query=branch%3Av3
+[rtcstats-server]: https://github.com/rtcstats/rtcstats

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ By adding query parameters into the URL you can set certain settings of the appl
 | `e2eKey`           | String | Key for media E2E encryption/decryption (just works with some OPUS and VP8 codecs) | |
 | `consumerReplicas` | Number | Create artificial replicas of yourself and receive their audio and video (not displayed in the UI) | 0 |
 | `usePipeTransports` | Boolean | If `true`, each room will use separate mediasoup routers to produce and consume and will communicate them with pipe transports | `false` |
-| `rtcstatsUrl`      | String  | If present, Websocket URL to connect to an [rtcstats-server], including token | |
+| `rtcstatsUrl`      | String  | If present, Websocket URL to connect to an [rtcstats-server](https://github.com/rtcstats/rtcstats), including token | |
 
 
 ## Installation
@@ -84,4 +84,3 @@ npm install --legacy-peer-deps
 
 [github-actions-shield-mediasoup-demo-server]: https://github.com/versatica/mediasoup-demo/actions/workflows/mediasoup-demo-server.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-demo-server]: https://github.com/versatica/mediasoup-demo/actions/workflows/mediasoup-demo-server.yaml?query=branch%3Av3
-[rtcstats-server]: https://github.com/rtcstats/rtcstats

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,6 +10,7 @@
 			"license": "All Rights Reserved",
 			"dependencies": {
 				"@babel/runtime": "7.29.2",
+				"@rtcstats/rtcstats-js": "^2.2.2",
 				"awaitqueue": "^3.3.0",
 				"bowser": "2.14.1",
 				"classnames": "2.5.1",
@@ -1596,6 +1597,21 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@rtcstats/rtcstats-js": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@rtcstats/rtcstats-js/-/rtcstats-js-2.2.2.tgz",
+			"integrity": "sha512-YLpkH7PdBYkDyTYshsV6Mi2PKlMAN0WJYcUEXDEfupYcWQunkMNam+zpcpojFrlZnRvNqrvg0Xl25j/7cc9tTA==",
+			"license": "MIT",
+			"dependencies": {
+				"@rtcstats/rtcstats-shared": "^2.0.0"
+			}
+		},
+		"node_modules/@rtcstats/rtcstats-shared": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@rtcstats/rtcstats-shared/-/rtcstats-shared-2.2.0.tgz",
+			"integrity": "sha512-MNE8aBqmatC1V5zLjvCj7ZNvY2IZkvL37ZFFoy3MCXI+bS6OyIghPNw5ZKqG51a11Ov87WTnnF/k6IbWXHs/xA==",
+			"license": "MIT"
 		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,7 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "7.29.2",
+		"@rtcstats/rtcstats-js": "^2.2.2",
 		"awaitqueue": "^3.3.0",
 		"bowser": "2.14.1",
 		"classnames": "2.5.1",

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -1,6 +1,7 @@
 import protooClient from 'protoo-client';
 import * as mediasoupClient from 'mediasoup-client';
 import { AwaitQueue } from 'awaitqueue';
+import { wrapRTCStatsWithDefaultOptions } from '@rtcstats/rtcstats-js';
 import Logger from './Logger';
 import { getProtooUrl } from './urlFactory';
 import * as cookiesManager from './cookiesManager';
@@ -200,6 +201,10 @@ export default class RoomClient {
 		// AwaitQueue to control received messages about Consumers and DataConsumers.
 		this._consumingAwaitQueue = new AwaitQueue();
 
+		// rtcstats-js tracer.
+		// See https://github.com/rtcstats/rtcstats-js
+		this._rtcstatsTrace = null;
+
 		if (externalVideo) {
 			this._externalVideo = document.createElement('video');
 
@@ -291,6 +296,11 @@ export default class RoomClient {
 		this._closed = true;
 
 		logger.debug('close()');
+
+		// Close rtcstats-js client.
+		if (this._rtcstatsTrace) {
+			this._rtcstatsTrace.close();
+		}
 
 		// Close protoo Peer
 		this._protoo.close();
@@ -2262,6 +2272,15 @@ export default class RoomClient {
 				)
 			);
 
+			const { rtcstatsUrl } = await this._protoo.request('getRtcStatsUrl');
+
+			if (rtcstatsUrl) {
+				logger.debug('_joinRoom() | got rtcstatsUrl: %o', rtcstatsUrl);
+
+				this._rtcstatsTrace = wrapRTCStatsWithDefaultOptions();
+				this._rtcstatsTrace.connect(rtcstatsUrl);
+			}
+
 			const { routerRtpCapabilities } = await this._protoo.request(
 				'getRouterRtpCapabilities'
 			);
@@ -2285,6 +2304,7 @@ export default class RoomClient {
 
 				setTimeout(() => audioTrack.stop(), 120000);
 			}
+
 			// Create mediasoup Transport for sending (unless we don't want to produce).
 			if (this._produce) {
 				const transportInfo = await this._protoo.request(

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -72,6 +72,7 @@ export default class RoomClient {
 		consumerReplicas,
 		usePipeTransports,
 		stats,
+		rtcstatsUrl,
 	}) {
 		logger.debug(
 			'constructor() [roomId:"%s", peerId:"%s", displayName:"%s", device:%s]',
@@ -204,6 +205,10 @@ export default class RoomClient {
 		// rtcstats-js tracer.
 		// See https://github.com/rtcstats/rtcstats-js
 		this._rtcstatsTrace = null;
+
+		// rtcstats server URL (if given via app query param or retrived from
+		// server).
+		this._rtcstatsUrl = rtcstatsUrl;
 
 		if (externalVideo) {
 			this._externalVideo = document.createElement('video');
@@ -2272,7 +2277,13 @@ export default class RoomClient {
 				)
 			);
 
-			const { rtcstatsUrl } = await this._protoo.request('getRtcStatsUrl');
+			let rtcstatsUrl;
+
+			if (this._rtcstatsUrl) {
+				rtcstatsUrl = this._rtcstatsUrl;
+			} else {
+				({ rtcstatsUrl } = await this._protoo.request('getRtcStatsUrl'));
+			}
 
 			if (rtcstatsUrl) {
 				logger.debug('_joinRoom() | got rtcstatsUrl: %o', rtcstatsUrl);

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -102,6 +102,7 @@ async function run() {
 	const e2eKey = urlParser.query.e2eKey;
 	const consumerReplicas = urlParser.query.consumerReplicas;
 	const usePipeTransports = urlParser.query.usePipeTransports === 'true';
+	const rtcstatsUrl = urlParser.query.rtcstatsUrl;
 
 	// Enable face detection on demand.
 	if (faceDetection)
@@ -227,6 +228,7 @@ async function run() {
 		consumerReplicas,
 		usePipeTransports,
 		stats,
+		rtcstatsUrl,
 	});
 
 	// NOTE: For debugging.

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -10,7 +10,6 @@ import {
 import thunk from 'redux-thunk';
 import randomString from 'random-string';
 import * as faceapi from 'face-api.js';
-import { wrapRTCStatsWithDefaultOptions } from '@rtcstats/rtcstats-js';
 import Logger from './Logger';
 import * as utils from './utils';
 import randomName from './randomName';
@@ -103,7 +102,6 @@ async function run() {
 	const e2eKey = urlParser.query.e2eKey;
 	const consumerReplicas = urlParser.query.consumerReplicas;
 	const usePipeTransports = urlParser.query.usePipeTransports === 'true';
-	const rtcstatsUrl = urlParser.query.rtcstatsUrl;
 
 	// Enable face detection on demand.
 	if (faceDetection)
@@ -197,12 +195,6 @@ async function run() {
 	store.dispatch(
 		stateActions.setMe({ peerId, displayName, displayNameSet, device })
 	);
-
-	if (rtcstatsUrl) {
-		const rtcstatsTrace = wrapRTCStatsWithDefaultOptions();
-
-		rtcstatsTrace.connect(rtcstatsUrl);
-	}
 
 	roomClient = new RoomClient({
 		roomId,

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -10,6 +10,7 @@ import {
 import thunk from 'redux-thunk';
 import randomString from 'random-string';
 import * as faceapi from 'face-api.js';
+import { wrapRTCStatsWithDefaultOptions } from '@rtcstats/rtcstats-js';
 import Logger from './Logger';
 import * as utils from './utils';
 import randomName from './randomName';
@@ -21,7 +22,6 @@ import * as stateActions from './redux/stateActions';
 import reducers from './redux/reducers';
 import Room from './components/Room';
 import './scss/index.scss';
-import { wrapRTCStatsWithDefaultOptions } from '@rtcstats/rtcstats-js';
 
 const logger = new Logger();
 const reduxMiddlewares = [thunk];
@@ -47,7 +47,6 @@ domready(async () => {
 
 window.RUN = run;
 
-let rtcstatsTrace;
 async function run() {
 	logger.debug('run() [environment:%s]', process.env.NODE_ENV);
 
@@ -104,6 +103,7 @@ async function run() {
 	const e2eKey = urlParser.query.e2eKey;
 	const consumerReplicas = urlParser.query.consumerReplicas;
 	const usePipeTransports = urlParser.query.usePipeTransports === 'true';
+	const rtcstatsUrl = urlParser.query.rtcstatsUrl;
 
 	// Enable face detection on demand.
 	if (faceDetection)
@@ -197,9 +197,10 @@ async function run() {
 	store.dispatch(
 		stateActions.setMe({ peerId, displayName, displayNameSet, device })
 	);
-	const rtcstatsUrl = urlParser.query.rtcstatsUrl;
+
 	if (rtcstatsUrl) {
-		rtcstatsTrace = wrapRTCStatsWithDefaultOptions();
+		const rtcstatsTrace = wrapRTCStatsWithDefaultOptions();
+
 		rtcstatsTrace.connect(rtcstatsUrl);
 	}
 

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -21,6 +21,7 @@ import * as stateActions from './redux/stateActions';
 import reducers from './redux/reducers';
 import Room from './components/Room';
 import './scss/index.scss';
+import { wrapRTCStatsWithDefaultOptions } from '@rtcstats/rtcstats-js';
 
 const logger = new Logger();
 const reduxMiddlewares = [thunk];
@@ -46,6 +47,7 @@ domready(async () => {
 
 window.RUN = run;
 
+let rtcstatsTrace;
 async function run() {
 	logger.debug('run() [environment:%s]', process.env.NODE_ENV);
 
@@ -195,6 +197,11 @@ async function run() {
 	store.dispatch(
 		stateActions.setMe({ peerId, displayName, displayNameSet, device })
 	);
+	const rtcstatsUrl = urlParser.query.rtcstatsUrl;
+	if (rtcstatsUrl) {
+		rtcstatsTrace = wrapRTCStatsWithDefaultOptions();
+		rtcstatsTrace.connect(rtcstatsUrl);
+	}
 
 	roomClient = new RoomClient({
 		roomId,

--- a/server/config.example.mjs
+++ b/server/config.example.mjs
@@ -187,4 +187,12 @@ export const config = {
 			maxSctpMessageSize: 262144,
 		},
 	},
+	providers: {
+		/**
+		 * URL to connect to rtcstats server from client.
+		 *
+		 * @see https://www.npmjs.com/package/@rtcstats/rtcstats-js.
+		 */
+		rtcstatsUrl: undefined,
+	},
 };

--- a/server/src/Peer.ts
+++ b/server/src/Peer.ts
@@ -75,6 +75,10 @@ export type PeerEvents = {
 	 */
 	'sctp-connected': [direction: TransportDirection];
 	/**
+	 * Emitted to obtain the rtcstats server URL.
+	 */
+	'get-rtcstats-url': [callback: (rtcstatsUrl?: string) => void];
+	/**
 	 * Emitted to obtain the mediasoup Router RTP capabilities.
 	 */
 	'get-router-rtp-capabilities': [
@@ -777,6 +781,14 @@ export class Peer extends EnhancedEventEmitter<PeerEvents> {
 		const { method, data, accept, reject } = request;
 
 		switch (method) {
+			case 'getRtcStatsUrl': {
+				this.emit('get-rtcstats-url', rtcstatsUrl => {
+					accept({ rtcstatsUrl });
+				});
+
+				break;
+			}
+
 			case 'getRouterRtpCapabilities': {
 				this.emit('get-router-rtp-capabilities', routerRtpCapabilities => {
 					accept({ routerRtpCapabilities });

--- a/server/src/Room.ts
+++ b/server/src/Room.ts
@@ -84,6 +84,10 @@ export type RoomEvents = {
 		resolve: () => void,
 		reject: (error: Error) => void,
 	];
+	/**
+	 * Emitted to obtain the rtcstats server URL.
+	 */
+	'get-rtcstats-url': [callback: (rtcstatsUrl?: string) => void];
 };
 
 export class Room extends EnhancedEventEmitter<RoomEvents> {
@@ -499,6 +503,12 @@ export class Room extends EnhancedEventEmitter<RoomEvents> {
 			if (direction == 'consumer') {
 				void peer.sendMessage(`Welcome ${peer.displayName}! ☺️`);
 			}
+		});
+
+		peer.on('get-rtcstats-url', callback => {
+			this.emit('get-rtcstats-url', rtcstatsUrl => {
+				callback(rtcstatsUrl);
+			});
 		});
 
 		peer.on('get-router-rtp-capabilities', callback => {

--- a/server/src/Server.ts
+++ b/server/src/Server.ts
@@ -643,5 +643,9 @@ export class Server extends EnhancedEventEmitter<ServerEvents> {
 		room.on('stop-network-throttle', ({ secret }, resolve, reject) => {
 			this.stopNetworkThrottle({ secret }).then(resolve).catch(reject);
 		});
+
+		room.on('get-rtcstats-url', resolve => {
+			resolve(this.#config.providers?.rtcstatsUrl);
+		});
 	}
 }

--- a/server/src/signaling/protooMessages.ts
+++ b/server/src/signaling/protooMessages.ts
@@ -107,6 +107,12 @@ export type TypedProtooNotificationFromPeer = {
  */
 type RequestFromPeer =
 	| {
+			name: 'getRtcStatsUrl';
+			responseData: {
+				rtcstatsUrl?: string;
+			};
+	  }
+	| {
 			name: 'getRouterRtpCapabilities';
 			responseData: {
 				routerRtpCapabilities: mediasoupTypes.RouterRtpCapabilities;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -42,6 +42,9 @@ export type ServerConfig = {
 			maxSctpMessageSize?: number;
 		};
 	};
+	providers?: {
+		rtcstatsUrl?: string;
+	};
 };
 
 export type RoomId = string;


### PR DESCRIPTION
_NOTE:_ [PR originally created](https://github.com/versatica/mediasoup-demo/pull/191) by @fippo but somehow I tried to push to his branch and ended creating a new one...

# Details

- Add `providers.rtcstatsUrl` option to server configuration file. If set, browser app receives it and connects its `rtcstats-js` client to it.
- Also allow passing `rtcstatsUrl` via query param in the browser URL (if given, it overrides the server config).
- This shows how to gather WebRTC API traces + getStats data similar to https://www.meetecho.com/blog/rtcstats-janus/
- No further integration with mediasoup-client is required. Small JS "binary" size impact, ~6kb.