### PR TITLE
Add automated redeploy of the demo server on v3 updates

### DIFF
--- a/.github/workflows/redeploy.yaml
+++ b/.github/workflows/redeploy.yaml
@@ -1,0 +1,47 @@
+name: redeploy
+
+# Triggers a redeploy of the demo server (https://v3demo.mediasoup.org) by
+# opening an SSH connection to it. No command is sent: the server runs the
+# forced command configured in the `deploy` user's authorized_keys
+# (the /home/deploy/update-mediasoup-demo-v3.sh script), which pulls the latest
+# v3 branch, installs deps, transpiles and restarts the PM2 service.
+#
+# It runs automatically on every push to v3 (including the bump committed by the
+# update-mediasoup workflow) and can also be triggered manually from the Actions
+# tab.
+on:
+  push:
+    branches: [v3]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    name: Trigger redeploy on the demo server
+    runs-on: ubuntu-26.04
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Trigger redeploy via SSH
+        run: |
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          install -m 600 /dev/null "$HOME/.ssh/deploy_key"
+          printf '%s\n' "${{ secrets.SSH_PRIVATE_KEY }}" > "$HOME/.ssh/deploy_key"
+          printf '%s\n' "${{ secrets.SSH_KNOWN_HOSTS }}" >> "$HOME/.ssh/known_hosts"
+
+          # No command is given on purpose: the server enforces the forced
+          # `command="...update-mediasoup-demo-v3.sh"` in authorized_keys, so
+          # that script is what actually runs. Its stdout/stderr is streamed
+          # back here and shown in the Actions logs.
+          ssh -i "$HOME/.ssh/deploy_key" \
+              -p "${{ secrets.SSH_PORT }}" \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+              "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}"

--- a/.github/workflows/update-mediasoup.yaml
+++ b/.github/workflows/update-mediasoup.yaml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-26.04
     permissions:
       contents: write
+      # Needed to dispatch the redeploy workflow once the bump is pushed.
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -59,6 +61,7 @@ jobs:
       # Commit and push only if something actually changed. The commit message
       # includes the version ("update mediasoup to X.Y.Z").
       - name: Commit and push
+        id: commit
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
         shell: bash
@@ -68,8 +71,19 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           if git diff --quiet -- server/package.json server/package-lock.json; then
             echo "mediasoup is already at ${VERSION}, nothing to commit"
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
           git add server/package.json server/package-lock.json
           git commit -m "update mediasoup to ${VERSION}"
           git push
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+
+      # A push made with the default GITHUB_TOKEN does NOT trigger other
+      # workflows, so dispatch the redeploy workflow explicitly (only if we
+      # actually pushed a bump).
+      - name: Trigger redeploy
+        if: steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run redeploy.yaml --ref v3

--- a/deploy/deploy-v3demo.sh
+++ b/deploy/deploy-v3demo.sh
@@ -1,35 +1,42 @@
 #/bin/bash
 
 #
-# This script must be placed into any subdirectory in the mediasoup-demo
-# project and must be executed from the root folder.
+# NOTE: This script is now deprecated because the logic is now automated via
+# GitHub CI workflow.
+#
+# See https://github.com/versatica/mediasoup-demo/pull/207
 #
 
-set -e
+# #
+# # This script must be placed into any subdirectory in the mediasoup-demo
+# # project and must be executed from the root folder.
+# #
 
-MEDIASOUP_DEMO_PWD=${PWD}
+# set -e
 
-current_dir_name=${MEDIASOUP_DEMO_PWD##*/}
-if [ "${current_dir_name}" != "mediasoup-demo" ] && [ "${current_dir_name}" != "v3-mediasoup-demo" ] ; then
-	echo ">>> [ERROR] $(basename $0) must be called from mediasoup-demo or v3-mediasoup-demo directory" >&2
-	exit 1
-fi
+# MEDIASOUP_DEMO_PWD=${PWD}
 
-if [ "$1" == "" ] || [ "$1" == "web" ]; then
-	cd app/
-	npm run build
-	rm -rf ../server/public
-	mv dist ../server/public
-	cd ../
-fi
+# current_dir_name=${MEDIASOUP_DEMO_PWD##*/}
+# if [ "${current_dir_name}" != "mediasoup-demo" ] && [ "${current_dir_name}" != "v3-mediasoup-demo" ] ; then
+# 	echo ">>> [ERROR] $(basename $0) must be called from mediasoup-demo or v3-mediasoup-demo directory" >&2
+# 	exit 1
+# fi
 
-if [ "$1" == "" ] || [ "$1" == "node" ]; then
-	rsync -avu --delete \
-		--exclude=/node_modules \
-		--exclude=/config.mjs \
-		--exclude=/lib \
-		server/ deploy@vhost1-deploy:/var/www/v3demo.mediasoup.org/
-fi
+# if [ "$1" == "" ] || [ "$1" == "web" ]; then
+# 	cd app/
+# 	npm run build
+# 	rm -rf ../server/public
+# 	mv dist ../server/public
+# 	cd ../
+# fi
 
-# And then ssh v2 with "deploy" user and run ./update-mediasoup-demo-server.sh.
+# if [ "$1" == "" ] || [ "$1" == "node" ]; then
+# 	rsync -avu --delete \
+# 		--exclude=/node_modules \
+# 		--exclude=/config.mjs \
+# 		--exclude=/lib \
+# 		server/ deploy@vhost1-deploy:/var/www/v3demo.mediasoup.org/
+# fi
+
+# # And then ssh v2 with "deploy" user and run ./update-mediasoup-demo-server.sh.
 


### PR DESCRIPTION
# Details

- New `redeploy` CI workflow:
  - It triggers on push to `v3`branch and via manual dispatch.
  - It opens an SSH connection to the demo server (using the `SSH_*` repository secrets) without sending any command.
  - The server runs the forced command set in the SSH user's `authorized_keys` which pulls the latest `v3`, rebuilds the client app into `server/public`, rebuilds the server, and restarts the PM2 service.
- `update-mediasoup` CI workflow:
  - Now it triggers the `redeploy` workflow after pushing a mediasoup bump.
  - Added `actions: write` permission
  - Made the commit step report whether it actually committed (changed output), and added a step that dispatches `redeploy` workflow only when a bump was pushed. This is required because pushes made with the default GITHUB_TOKEN do not trigger other workflows.
- Deprecate `deploy/deploy-v3demo.sh` script.